### PR TITLE
Add application settings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,8 @@ Changes
 
   - ``--ble-adapter`` / ``CALYPSO_BLE_ADAPTER``
   - ``--ble-address`` / ``CALYPSO_BLE_ADDRESS``
+  - ``--ble-discovery-timeout`` / ``CALYPSO_BLE_DISCOVERY_TIMEOUT``
+  - ``--ble-connect-timeout`` / ``CALYPSO_BLE_CONNECT_TIMEOUT``
 
 
 Breaking changes

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ calypso-anemometer changelog
 
 in progress
 ===========
+
+Changes
+-------
 - Fix import error on Python 3.7
   ``AttributeError: module 'asyncio' has no attribute 'exceptions'``
 - Add a few more software tests
@@ -18,6 +21,13 @@ in progress
   through command line options or environment variables.
 
   - ``--ble-adapter`` / ``CALYPSO_BLE_ADAPTER``
+  - ``--ble-address`` / ``CALYPSO_BLE_ADDRESS``
+
+
+Breaking changes
+----------------
+- The ``CALYPSO_ADDRESS`` environment variable has been renamed to
+  ``CALYPSO_BLE_ADDRESS``.
 
 
 2022-07-25 0.4.0

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,7 +17,7 @@ Changes
 - Emit ``CalypsoDecodingError`` exceptions when decoding wire data fails
 - Refactor workhorse functions from ``cli.py`` to ``engine.py``
 - Significantly improve test coverage
-- Introduce ``ApplicationSettings``, to bundle configuration settings
+- Introduce ``Settings``, to bundle configuration settings
   through command line options or environment variables.
 
   - ``--ble-adapter`` / ``CALYPSO_BLE_ADAPTER``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,7 +25,6 @@ Changes
   - ``--ble-discovery-timeout`` / ``CALYPSO_BLE_DISCOVERY_TIMEOUT``
   - ``--ble-connect-timeout`` / ``CALYPSO_BLE_CONNECT_TIMEOUT``
 
-
 Breaking changes
 ----------------
 - The ``CALYPSO_ADDRESS`` environment variable has been renamed to

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,10 @@ in progress
 - Emit ``CalypsoDecodingError`` exceptions when decoding wire data fails
 - Refactor workhorse functions from ``cli.py`` to ``engine.py``
 - Significantly improve test coverage
+- Introduce ``ApplicationSettings``, to bundle configuration settings
+  through command line options or environment variables.
+
+  - ``--ble-adapter`` / ``CALYPSO_BLE_ADAPTER``
 
 
 2022-07-25 0.4.0

--- a/README.rst
+++ b/README.rst
@@ -93,9 +93,12 @@ Usage
 Command line
 ============
 
-Discover the ``ULTRASONIC`` BLE device and run a conversation on it::
+Discover the ``ULTRASONIC`` BLE device and run a conversation on it. By
+default, the Bluetooth adapter ``hci0`` will be used.
 
-    # Get device information.
+::
+
+    # Get device information with discovery.
     calypso-anemometer info
 
     # Get device reading.
@@ -114,12 +117,31 @@ Discover the ``ULTRASONIC`` BLE device and run a conversation on it::
 If you already discovered your device, know its address, and want to connect
 directly without automatic device discovery, see `skip discovery`_.
 
+Likewise, when your system has multiple Bluetooth adapters, you may want to
+choose a specific one, see `increase BLE timeout values`_.
+
+::
+
+    # Get device information w/o discovery.
+    calypso-anemometer info --ble-address=F8:C7:2C:EC:13:D0
+
+    # Get device information w/o discovery, using a specific Bluetooth adapter.
+    calypso-anemometer info --ble-adapter=hci1 --ble-address=F8:C7:2C:EC:13:D0
+
 
 Library
 =======
 
 In order to use the library API, please consult the programs in the
 ``examples`` folder.
+
+Synopsis::
+
+    from calypso_anemometer.core import CalypsoDeviceApi
+
+    async with CalypsoDeviceApi() as calypso:
+        reading = await calypso.get_reading()
+        reading.print()
 
 
 
@@ -188,7 +210,8 @@ Troubleshooting
 ***************
 
 For helping you to find solutions for known problems, we are maintaining
-a dedicated page at `troubleshooting`_.
+a dedicated page at `troubleshooting`_. The topic range is from permission
+errors to BLE timeouts.
 
 
 ****************
@@ -239,6 +262,7 @@ The project is licensed under the terms of the GNU AGPL license.
 .. _David Lechner: https://github.com/dlech
 .. _Fabian Tollenaar: https://github.com/fabdrol
 .. _Henrik Blidh: https://github.com/hbldh
+.. _increase BLE timeout values: https://github.com/maritime-labs/calypso-anemometer/blob/main/doc/troubleshooting.rst#increase-ble-timeout-values
 .. _OpenCPN: https://opencpn.org/
 .. _OpenPlotter: https://open-boat-projects.org/en/openplotter/
 .. _preflight checks: https://github.com/maritime-labs/calypso-anemometer/blob/main/doc/preflight.rst

--- a/calypso_anemometer/cli.py
+++ b/calypso_anemometer/cli.py
@@ -53,6 +53,22 @@ ble_address_option = click.option(
     required=False,
     help="Calypso peripheral BLE address, for connection without discovery.",
 )
+ble_discovery_timeout_option = click.option(
+    "--ble-discovery-timeout",
+    envvar="CALYPSO_BLE_DISCOVERY_TIMEOUT",
+    type=float,
+    required=False,
+    default=10.0,
+    help="Timeout for BLE discovery in seconds. Default: 10.0",
+)
+ble_connect_timeout_option = click.option(
+    "--ble-connect-timeout",
+    envvar="CALYPSO_BLE_CONNECT_TIMEOUT",
+    type=float,
+    required=False,
+    default=10.0,
+    help="Timeout for BLE connect in seconds. Default: 10.0",
+)
 rate_option = click.option(
     "--rate",
     type=EnumChoice(CalypsoDeviceDataRate, case_sensitive=False),
@@ -66,6 +82,8 @@ target_option = click.option("--target", type=str, required=False, help="Submit 
 @click.command()
 @ble_adapter_option
 @ble_address_option
+@ble_discovery_timeout_option
+@ble_connect_timeout_option
 @click.option(
     "--mode",
     type=EnumChoice(CalypsoDeviceMode, case_sensitive=False),
@@ -77,8 +95,10 @@ target_option = click.option("--target", type=str, required=False, help="Submit 
 @make_sync
 async def set_option(
     ctx,
-    ble_adapter: str = None,
-    ble_address: str = None,
+    ble_adapter: t.Optional[str] = None,
+    ble_address: t.Optional[str] = None,
+    ble_discovery_timeout: t.Optional[float] = None,
+    ble_connect_timeout: t.Optional[float] = None,
     mode: t.Optional[CalypsoDeviceMode] = None,
     rate: t.Optional[CalypsoDeviceDataRate] = None,
 ):
@@ -91,13 +111,20 @@ async def set_option(
             await calypso.set_datarate(rate)
         await calypso.about()
 
-    settings = ApplicationSettings(ble_adapter=ble_adapter, ble_address=ble_address)
+    settings = ApplicationSettings(
+        ble_adapter=ble_adapter,
+        ble_address=ble_address,
+        ble_discovery_timeout=ble_discovery_timeout,
+        ble_connect_timeout=ble_connect_timeout,
+    )
     await run_engine(workhorse=CalypsoDeviceApi, settings=settings, handler=handler)
 
 
 @click.command()
 @ble_adapter_option
 @ble_address_option
+@ble_discovery_timeout_option
+@ble_connect_timeout_option
 @subscribe_option
 @target_option
 @rate_option
@@ -105,13 +132,20 @@ async def set_option(
 @make_sync
 async def read(
     ctx,
-    ble_adapter: str = None,
-    ble_address: str = None,
-    subscribe: bool = False,
+    ble_adapter: t.Optional[str] = None,
+    ble_address: t.Optional[str] = None,
+    ble_discovery_timeout: t.Optional[float] = None,
+    ble_connect_timeout: t.Optional[float] = None,
+    subscribe: t.Optional[bool] = False,
     target: t.Optional[str] = None,
     rate: t.Optional[CalypsoDeviceDataRate] = None,
 ):
-    settings = ApplicationSettings(ble_adapter=ble_adapter, ble_address=ble_address)
+    settings = ApplicationSettings(
+        ble_adapter=ble_adapter,
+        ble_address=ble_address,
+        ble_discovery_timeout=ble_discovery_timeout,
+        ble_connect_timeout=ble_connect_timeout,
+    )
     handler = await handler_factory(subscribe=subscribe, target=target, rate=rate)
     await run_engine(workhorse=CalypsoDeviceApi, settings=settings, handler=handler)
 

--- a/calypso_anemometer/cli.py
+++ b/calypso_anemometer/cli.py
@@ -46,6 +46,13 @@ ble_adapter_option = click.option(
     default="hci0",
     help="Which Bluetooth adapter to use, e.g. `hci1`. Default: `hci0`",
 )
+ble_address_option = click.option(
+    "--ble-address",
+    envvar="CALYPSO_BLE_ADDRESS",
+    type=str,
+    required=False,
+    help="Calypso peripheral BLE address, for connection without discovery.",
+)
 rate_option = click.option(
     "--rate",
     type=EnumChoice(CalypsoDeviceDataRate, case_sensitive=False),
@@ -58,6 +65,7 @@ target_option = click.option("--target", type=str, required=False, help="Submit 
 
 @click.command()
 @ble_adapter_option
+@ble_address_option
 @click.option(
     "--mode",
     type=EnumChoice(CalypsoDeviceMode, case_sensitive=False),
@@ -70,6 +78,7 @@ target_option = click.option("--target", type=str, required=False, help="Submit 
 async def set_option(
     ctx,
     ble_adapter: str = None,
+    ble_address: str = None,
     mode: t.Optional[CalypsoDeviceMode] = None,
     rate: t.Optional[CalypsoDeviceDataRate] = None,
 ):
@@ -82,12 +91,13 @@ async def set_option(
             await calypso.set_datarate(rate)
         await calypso.about()
 
-    settings = ApplicationSettings(ble_adapter=ble_adapter)
+    settings = ApplicationSettings(ble_adapter=ble_adapter, ble_address=ble_address)
     await run_engine(workhorse=CalypsoDeviceApi, settings=settings, handler=handler)
 
 
 @click.command()
 @ble_adapter_option
+@ble_address_option
 @subscribe_option
 @target_option
 @rate_option
@@ -96,11 +106,12 @@ async def set_option(
 async def read(
     ctx,
     ble_adapter: str = None,
+    ble_address: str = None,
     subscribe: bool = False,
     target: t.Optional[str] = None,
     rate: t.Optional[CalypsoDeviceDataRate] = None,
 ):
-    settings = ApplicationSettings(ble_adapter=ble_adapter)
+    settings = ApplicationSettings(ble_adapter=ble_adapter, ble_address=ble_address)
     handler = await handler_factory(subscribe=subscribe, target=target, rate=rate)
     await run_engine(workhorse=CalypsoDeviceApi, settings=settings, handler=handler)
 

--- a/calypso_anemometer/cli.py
+++ b/calypso_anemometer/cli.py
@@ -9,7 +9,7 @@ import click
 from calypso_anemometer.core import CalypsoDeviceApi
 from calypso_anemometer.engine import handler_factory, run_engine
 from calypso_anemometer.fake import CalypsoDeviceApiFake
-from calypso_anemometer.model import ApplicationSettings, CalypsoDeviceDataRate, CalypsoDeviceMode
+from calypso_anemometer.model import CalypsoDeviceDataRate, CalypsoDeviceMode, Settings
 from calypso_anemometer.util import EnumChoice, make_sync, setup_logging
 
 logger = logging.getLogger(__name__)
@@ -111,7 +111,7 @@ async def set_option(
             await calypso.set_datarate(rate)
         await calypso.about()
 
-    settings = ApplicationSettings(
+    settings = Settings(
         ble_adapter=ble_adapter,
         ble_address=ble_address,
         ble_discovery_timeout=ble_discovery_timeout,
@@ -140,7 +140,7 @@ async def read(
     target: t.Optional[str] = None,
     rate: t.Optional[CalypsoDeviceDataRate] = None,
 ):
-    settings = ApplicationSettings(
+    settings = Settings(
         ble_adapter=ble_adapter,
         ble_address=ble_address,
         ble_discovery_timeout=ble_discovery_timeout,

--- a/calypso_anemometer/core.py
+++ b/calypso_anemometer/core.py
@@ -69,6 +69,8 @@ class CalypsoDeviceApi:
         self.ble_address = settings.ble_address
         self.client: BleakClient
 
+        logger.info(f"Initializing client with {self.settings}")
+
     async def __aenter__(self):
 
         if self.ble_address is None:

--- a/calypso_anemometer/core.py
+++ b/calypso_anemometer/core.py
@@ -26,7 +26,6 @@ from calypso_anemometer.exception import (
     CalypsoDecodingError,
 )
 from calypso_anemometer.model import (
-    ApplicationSettings,
     BleCharSpec,
     CalypsoDeviceDataRate,
     CalypsoDeviceInfo,
@@ -36,6 +35,7 @@ from calypso_anemometer.model import (
     CalypsoDeviceStatus,
     CalypsoDeviceStatusCharacteristic,
     CalypsoReading,
+    Settings,
 )
 from calypso_anemometer.util import to_json
 
@@ -62,9 +62,9 @@ class CalypsoDeviceApi:
         CalypsoDeviceStatusCharacteristic.compass,
     ]
 
-    def __init__(self, settings: Optional[ApplicationSettings] = None, ble_address: Optional[str] = None):
+    def __init__(self, settings: Optional[Settings] = None, ble_address: Optional[str] = None):
         if settings is None:
-            settings = ApplicationSettings(ble_address=ble_address)
+            settings = Settings(ble_address=ble_address)
         self.settings = settings
         self.ble_address = settings.ble_address
         self.client: BleakClient

--- a/calypso_anemometer/engine.py
+++ b/calypso_anemometer/engine.py
@@ -2,7 +2,6 @@
 # (c) 2022 Andreas Motl <andreas.motl@panodata.org>
 # License: GNU Affero General Public License, Version 3
 import logging
-import os
 import sys
 import typing as t
 
@@ -20,7 +19,7 @@ async def run_engine(workhorse, handler: t.Callable, settings: t.Optional[Applic
     Create a workhorse engine and connect it with the asynchronous handler function for processing readings.
     """
     try:
-        worker = workhorse(settings=settings, ble_address=os.getenv("CALYPSO_ADDRESS"))
+        worker = workhorse(settings=settings)
         async with worker as calypso:
             await handler(calypso)
     except CalypsoError as ex:

--- a/calypso_anemometer/engine.py
+++ b/calypso_anemometer/engine.py
@@ -8,19 +8,19 @@ import typing as t
 
 from calypso_anemometer.core import CalypsoDeviceApi
 from calypso_anemometer.exception import CalypsoError
-from calypso_anemometer.model import CalypsoDeviceDataRate, CalypsoReading
+from calypso_anemometer.model import ApplicationSettings, CalypsoDeviceDataRate, CalypsoReading
 from calypso_anemometer.telemetry.adapter import TelemetryAdapter
 from calypso_anemometer.util import wait_forever
 
 logger = logging.getLogger(__name__)
 
 
-async def run_engine(workhorse, handler: t.Callable):
+async def run_engine(workhorse, handler: t.Callable, settings: t.Optional[ApplicationSettings] = None):
     """
     Create a workhorse engine and connect it with the asynchronous handler function for processing readings.
     """
     try:
-        worker = workhorse(ble_address=os.getenv("CALYPSO_ADDRESS"))
+        worker = workhorse(settings=settings, ble_address=os.getenv("CALYPSO_ADDRESS"))
         async with worker as calypso:
             await handler(calypso)
     except CalypsoError as ex:

--- a/calypso_anemometer/engine.py
+++ b/calypso_anemometer/engine.py
@@ -7,14 +7,14 @@ import typing as t
 
 from calypso_anemometer.core import CalypsoDeviceApi
 from calypso_anemometer.exception import CalypsoError
-from calypso_anemometer.model import ApplicationSettings, CalypsoDeviceDataRate, CalypsoReading
+from calypso_anemometer.model import CalypsoDeviceDataRate, CalypsoReading, Settings
 from calypso_anemometer.telemetry.adapter import TelemetryAdapter
 from calypso_anemometer.util import wait_forever
 
 logger = logging.getLogger(__name__)
 
 
-async def run_engine(workhorse, handler: t.Callable, settings: t.Optional[ApplicationSettings] = None):
+async def run_engine(workhorse, handler: t.Callable, settings: t.Optional[Settings] = None):
     """
     Create a workhorse engine and connect it with the asynchronous handler function for processing readings.
     """

--- a/calypso_anemometer/fake.py
+++ b/calypso_anemometer/fake.py
@@ -8,7 +8,7 @@ from typing import Callable, Optional
 
 import aiorate
 
-from calypso_anemometer.model import CalypsoDeviceDataRate, CalypsoReading
+from calypso_anemometer.model import ApplicationSettings, CalypsoDeviceDataRate, CalypsoReading
 
 logger = logging.getLogger(__name__)
 
@@ -38,8 +38,11 @@ class CalypsoDeviceApiFake:
     NAME = "calypso-up10-fake"
     DESCRIPTION = "Calypso UP10 anemometer fake device"
 
-    def __init__(self, ble_address: Optional[str] = None):
-        self.ble_address: str = ble_address
+    def __init__(self, settings: Optional[ApplicationSettings] = None, ble_address: Optional[str] = None):
+        if settings is None:
+            settings = ApplicationSettings(ble_address=ble_address)
+        self.settings = settings
+        self.ble_address = settings.ble_address
         self.datarate: CalypsoDeviceDataRate = CalypsoDeviceDataRate.HZ_4
         self.reading: Optional[CalypsoReading] = None
 

--- a/calypso_anemometer/fake.py
+++ b/calypso_anemometer/fake.py
@@ -8,7 +8,7 @@ from typing import Callable, Optional
 
 import aiorate
 
-from calypso_anemometer.model import ApplicationSettings, CalypsoDeviceDataRate, CalypsoReading
+from calypso_anemometer.model import CalypsoDeviceDataRate, CalypsoReading, Settings
 
 logger = logging.getLogger(__name__)
 
@@ -38,9 +38,9 @@ class CalypsoDeviceApiFake:
     NAME = "calypso-up10-fake"
     DESCRIPTION = "Calypso UP10 anemometer fake device"
 
-    def __init__(self, settings: Optional[ApplicationSettings] = None, ble_address: Optional[str] = None):
+    def __init__(self, settings: Optional[Settings] = None, ble_address: Optional[str] = None):
         if settings is None:
-            settings = ApplicationSettings(ble_address=ble_address)
+            settings = Settings(ble_address=ble_address)
         self.settings = settings
         self.ble_address = settings.ble_address
         self.datarate: CalypsoDeviceDataRate = CalypsoDeviceDataRate.HZ_4

--- a/calypso_anemometer/model.py
+++ b/calypso_anemometer/model.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 @dataclasses.dataclass
-class ApplicationSettings:
+class Settings:
     ble_adapter: Optional[str] = "hci0"
     ble_address: Optional[str] = None
     ble_discovery_timeout: Optional[float] = 10.0

--- a/calypso_anemometer/model.py
+++ b/calypso_anemometer/model.py
@@ -13,6 +13,14 @@ logger = logging.getLogger(__name__)
 
 
 @dataclasses.dataclass
+class ApplicationSettings:
+    ble_adapter: Optional[str] = "hci0"
+    ble_address: Optional[str] = None
+    ble_discovery_timeout: Optional[float] = 10.0
+    ble_connect_timeout: Optional[float] = 10.0
+
+
+@dataclasses.dataclass
 class BleCharSpec:
     name: str
     uuid: str

--- a/doc/backlog.rst
+++ b/doc/backlog.rst
@@ -66,7 +66,7 @@ Topic: QA
 - [x] Tests: Don't use port 10110 within software tests
 - [x] Naming things: Telemetry subsystem
 - [x] Naming things: ``Nmea0183Envelope``
-- [x] Add test for ``CALYPSO_ADDRESS`` environment variable
+- [x] Add test for ``CALYPSO_BLE_ADDRESS`` environment variable
 - [x] CLI: Rework ``about`` command: Output a single result document to improve testing
 
 
@@ -75,10 +75,10 @@ Iteration +2.5
 **************
 Topic: Production
 
-- [o] Introduce ``ApplicationSettings`` container entity, for the following three options/settings
-- [o] BLE: Select BLE adapter, using ``--ble-adapter`` or ``CALYPSO_BLE_ADAPTER``
-- [o] BLE: Obtain peripheral address from both ``--ble-address`` or ``CALYPSO_BLE_ADDRESS``
-- [o] BLE: Unlock ``--ble-timeout`` or ``CALYPSO_BLE_TIMEOUT``
+- [x] Introduce ``ApplicationSettings`` container entity, for the following three options/settings
+- [x] BLE: Select BLE adapter, using ``--ble-adapter`` or ``CALYPSO_BLE_ADAPTER``
+- [x] BLE: Obtain peripheral address from both ``--ble-address`` or ``CALYPSO_BLE_ADDRESS``
+- [x] BLE: Unlock ``--ble-*-timeout`` or ``CALYPSO_BLE_*_TIMEOUT``
 - [o] Turn off logging to STDOUT
 - [o] Systemd unit, with installer
 - [o] Day/night switching

--- a/doc/backlog.rst
+++ b/doc/backlog.rst
@@ -75,7 +75,7 @@ Iteration +2.5
 **************
 Topic: Production
 
-- [x] Introduce ``ApplicationSettings`` container entity, for the following three options/settings
+- [x] Introduce ``Settings`` container entity, for the following three options/settings
 - [x] BLE: Select BLE adapter, using ``--ble-adapter`` or ``CALYPSO_BLE_ADAPTER``
 - [x] BLE: Obtain peripheral address from both ``--ble-address`` or ``CALYPSO_BLE_ADDRESS``
 - [x] BLE: Unlock ``--ble-*-timeout`` or ``CALYPSO_BLE_*_TIMEOUT``

--- a/doc/preflight.rst
+++ b/doc/preflight.rst
@@ -52,8 +52,12 @@ Run a BLE device scan on a specific adapter using ``hcitool``::
 
 Run a BLE device scan using Bleak::
 
+    # Use different Bluetooth adapters.
     bleak-lescan -i hci0
     bleak-lescan -i hci1
+
+    # Increase discovery timeout.
+    bleak-lescan -t 30
 
 
 

--- a/doc/production.rst
+++ b/doc/production.rst
@@ -3,6 +3,28 @@ Production notes
 ################
 
 
+***************************
+Multiple Bluetooth adapters
+***************************
+
+If your system sports multiple Bluetooth adapters, you might want to select the
+right one to use with the program.
+
+For that purpose, you can use the ``--ble-adapter`` command line option, like::
+
+    calypso-anemometer info --ble-adapter=hci1
+    calypso-anemometer read --ble-adapter=hci1
+
+Alternatively, you can use the ``CALYPSO_BLE_ADAPTER`` environment variable, like::
+
+    export CALYPSO_BLE_ADAPTER=hci1
+    calypso-anemometer info
+
+In order to use the default again, use::
+
+    unset CALYPSO_BLE_ADAPTER
+
+
 *************************************
 Device discovery vs. multiple devices
 *************************************
@@ -15,15 +37,22 @@ multiple devices with the same name are around and you will be connecting to the
 wrong device. This scenario also applies when you are using multiple devices on
 your own site.
 
-In this case, make sure to shortcut the device discovery procedure by pinning the
-BLE peripheral. For that purpose, you can use the ``CALYPSO_BLE_ADDRESS`` environment
-variable, like::
+In this case, make sure to shortcut the device discovery procedure by addressing
+the BLE peripheral directly. For that purpose, you can use the ``--ble-address``
+command line option, like::
+
+    calypso-anemometer info --ble-address=F8:C7:2C:EC:13:D0
+    calypso-anemometer read --ble-address=F8:C7:2C:EC:13:D0
+
+Alternatively, you can use the ``CALYPSO_BLE_ADDRESS`` environment variable, like::
 
     # Linux
     export CALYPSO_BLE_ADDRESS=F8:C7:2C:EC:13:D0
+    calypso-anemometer info
 
     # macOS
     export CALYPSO_BLE_ADDRESS=0C3E4A46-BFCB-52E5-BC57-DE1D60C3A2B2
+    calypso-anemometer info
 
 In order to activate automatic device discovery again, invoke::
 

--- a/doc/production.rst
+++ b/doc/production.rst
@@ -16,18 +16,18 @@ wrong device. This scenario also applies when you are using multiple devices on
 your own site.
 
 In this case, make sure to shortcut the device discovery procedure by pinning the
-BLE peripheral. For that purpose, you can use the ``CALYPSO_ADDRESS`` environment
+BLE peripheral. For that purpose, you can use the ``CALYPSO_BLE_ADDRESS`` environment
 variable, like::
 
     # Linux
-    export CALYPSO_ADDRESS=F8:C7:2C:EC:13:D0
+    export CALYPSO_BLE_ADDRESS=F8:C7:2C:EC:13:D0
 
     # macOS
-    export CALYPSO_ADDRESS=0C3E4A46-BFCB-52E5-BC57-DE1D60C3A2B2
+    export CALYPSO_BLE_ADDRESS=0C3E4A46-BFCB-52E5-BC57-DE1D60C3A2B2
 
 In order to activate automatic device discovery again, invoke::
 
-    unset CALYPSO_ADDRESS
+    unset CALYPSO_BLE_ADDRESS
 
 
 *********************

--- a/doc/troubleshooting.rst
+++ b/doc/troubleshooting.rst
@@ -3,6 +3,19 @@ calypso-anemometer troubleshooting
 ##################################
 
 
+***************************
+Increase BLE timeout values
+***************************
+
+BLE knows two timeout options, the *discovery timeout* and the *connect
+timeout*. Following the default settings from the Bleak library, both values
+are *10.0* seconds by default. In order to adjust them, use the corresponding
+command line options or environment variables.
+
+- ``--ble-discovery-timeout`` / ``CALYPSO_BLE_DISCOVERY_TIMEOUT``
+- ``--ble-connect-timeout`` / ``CALYPSO_BLE_CONNECT_TIMEOUT``
+
+
 ************************************************
 Submitting telemetry data to ``255.255.255.255``
 ************************************************

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -4,8 +4,6 @@
 import pytest
 from pytest_mock import MockerFixture
 
-from calypso_anemometer.core import CalypsoDeviceApi
-
 
 @pytest.fixture(autouse=True)
 def use_stable_cross_platform_bluetooth_adapter(mocker: MockerFixture):
@@ -13,4 +11,4 @@ def use_stable_cross_platform_bluetooth_adapter(mocker: MockerFixture):
     Make sure the tests will always use the designated bluetooth adapter.
     Otherwise, the outcome will deviate on Linux vs. macOS.
     """
-    mocker.patch("calypso_anemometer.core.get_adapter_name", return_value=CalypsoDeviceApi.BLUETOOTH_ADAPTER)
+    mocker.patch("calypso_anemometer.core.get_adapter_name", return_value="hci0")

--- a/testing/test_cli.py
+++ b/testing/test_cli.py
@@ -212,6 +212,26 @@ def test_cli_read_telemetry_success(caplog):
     AsyncMock(return_value=BLEDevice(name="foo", address="bar")),
 )
 @mock.patch("calypso_anemometer.core.BleakClient.connect", AsyncMock(return_value=None))
+@mock.patch("calypso_anemometer.core.BleakClient.read_gatt_char", AsyncMock(return_value=dummy_wire_message_good))
+def test_cli_read_ble_adapter_success(mocker, caplog):
+    """
+    Test successful `calypso-anemometer read --ble-adapter=...`.
+    """
+
+    mocker.patch("calypso_anemometer.core.get_adapter_name", return_value="hci99")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["read", "--ble-adapter=hci99"], catch_exceptions=False)
+    assert result.exit_code == 0
+
+    assert "Connecting to device at 'bar' with adapter 'hci99'" in caplog.messages
+
+
+@mock.patch(
+    "calypso_anemometer.core.BleakScanner.find_device_by_filter",
+    AsyncMock(return_value=BLEDevice(name="foo", address="bar")),
+)
+@mock.patch("calypso_anemometer.core.BleakClient.connect", AsyncMock(return_value=None))
 @mock.patch("calypso_anemometer.core.BleakClient.write_gatt_char", AsyncMock(return_value=None))
 @mock.patch("calypso_anemometer.core.CalypsoDeviceApi.get_info", AsyncMock(return_value=dummy_device_info))
 @mock.patch("calypso_anemometer.core.CalypsoDeviceApi.get_status", AsyncMock(return_value=dummy_device_status))

--- a/testing/test_cli.py
+++ b/testing/test_cli.py
@@ -113,7 +113,7 @@ def test_cli_read_stdout_success(caplog):
     }
 
     assert (
-        "Initializing client with ApplicationSettings(ble_adapter='hci0', ble_address=None, "
+        "Initializing client with Settings(ble_adapter='hci0', ble_address=None, "
         "ble_discovery_timeout=10.0, ble_connect_timeout=10.0)" in caplog.messages
     )
     assert "Using BLE discovery to find Calypso UP10 anemometer" in caplog.messages
@@ -231,7 +231,7 @@ def test_cli_read_ble_adapter_success(mocker, caplog):
     assert result.exit_code == 0
 
     assert (
-        "Initializing client with ApplicationSettings(ble_adapter='hci99', ble_address=None, "
+        "Initializing client with Settings(ble_adapter='hci99', ble_address=None, "
         "ble_discovery_timeout=10.0, ble_connect_timeout=10.0)" in caplog.messages
     )
     assert "Connecting to device at 'bar' with adapter 'hci99'" in caplog.messages
@@ -249,7 +249,7 @@ def test_cli_read_ble_address_option_success(caplog):
     assert result.exit_code == 0
 
     assert (
-        "Initializing client with ApplicationSettings(ble_adapter='hci0', ble_address='F8:C7:2C:EC:13:D0', "
+        "Initializing client with Settings(ble_adapter='hci0', ble_address='F8:C7:2C:EC:13:D0', "
         "ble_discovery_timeout=10.0, ble_connect_timeout=10.0)" in caplog.messages
     )
     assert "Connecting to device at 'F8:C7:2C:EC:13:D0' with adapter 'hci0'" in caplog.messages
@@ -269,7 +269,7 @@ def test_cli_read_ble_address_envvar_success(mocker: MockerFixture, caplog):
     assert result.exit_code == 0
 
     assert (
-        "Initializing client with ApplicationSettings(ble_adapter='hci0', ble_address='F8:C7:2C:EC:13:D0', "
+        "Initializing client with Settings(ble_adapter='hci0', ble_address='F8:C7:2C:EC:13:D0', "
         "ble_discovery_timeout=10.0, ble_connect_timeout=10.0)" in caplog.messages
     )
     assert "Connecting to device at 'F8:C7:2C:EC:13:D0' with adapter 'hci0'" in caplog.messages
@@ -291,7 +291,7 @@ def test_cli_read_ble_timeout_success(mocker: MockerFixture, caplog):
     assert result.exit_code == 0
 
     assert (
-        "Initializing client with ApplicationSettings(ble_adapter='hci0', ble_address='F8:C7:2C:EC:13:D0', "
+        "Initializing client with Settings(ble_adapter='hci0', ble_address='F8:C7:2C:EC:13:D0', "
         "ble_discovery_timeout=8.8, ble_connect_timeout=7.7)" in caplog.messages
     )
 

--- a/testing/test_engine.py
+++ b/testing/test_engine.py
@@ -5,7 +5,7 @@ import sys
 
 import pytest
 
-from calypso_anemometer.model import ApplicationSettings
+from calypso_anemometer.model import Settings
 
 if sys.version_info < (3, 8, 0):
     raise pytest.skip(reason="AsyncMock not supported on Python 3.7", allow_module_level=True)
@@ -41,7 +41,7 @@ async def test_run_engine_with_address_success(mocker: MockerFixture):
     mocker.patch("calypso_anemometer.core.BleakClient.connect", AsyncMock(return_value=None))
     mocker.patch("calypso_anemometer.core.BleakClient.read_gatt_char", AsyncMock(return_value=dummy_wire_message_good))
 
-    settings = ApplicationSettings(ble_address="F8:C7:2C:EC:13:D0")
+    settings = Settings(ble_address="F8:C7:2C:EC:13:D0")
     handler = await handler_factory()
     worker: CalypsoDeviceApi = await run_engine(workhorse=CalypsoDeviceApi, settings=settings, handler=handler)
     assert worker.ble_address == "F8:C7:2C:EC:13:D0"

--- a/testing/test_engine.py
+++ b/testing/test_engine.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 # (c) 2022 Andreas Motl <andreas.motl@panodata.org>
 # License: GNU Affero General Public License, Version 3
-import os
 import sys
 
 import pytest
+
+from calypso_anemometer.model import ApplicationSettings
 
 if sys.version_info < (3, 8, 0):
     raise pytest.skip(reason="AsyncMock not supported on Python 3.7", allow_module_level=True)
@@ -35,16 +36,12 @@ async def test_run_engine_vanilla_success(mocker: MockerFixture):
 
 
 @pytest.mark.asyncio
-async def test_run_engine_envvar_address_success(mocker: MockerFixture):
+async def test_run_engine_with_address_success(mocker: MockerFixture):
 
-    mocker.patch(
-        "calypso_anemometer.core.BleakScanner.find_device_by_filter",
-        AsyncMock(return_value=BLEDevice(name="foo", address="bar")),
-    )
-    mocker.patch.dict(os.environ, {"CALYPSO_ADDRESS": "other_device"})
     mocker.patch("calypso_anemometer.core.BleakClient.connect", AsyncMock(return_value=None))
     mocker.patch("calypso_anemometer.core.BleakClient.read_gatt_char", AsyncMock(return_value=dummy_wire_message_good))
 
+    settings = ApplicationSettings(ble_address="F8:C7:2C:EC:13:D0")
     handler = await handler_factory()
-    worker: CalypsoDeviceApi = await run_engine(workhorse=CalypsoDeviceApi, handler=handler)
-    assert worker.ble_address == "other_device"
+    worker: CalypsoDeviceApi = await run_engine(workhorse=CalypsoDeviceApi, settings=settings, handler=handler)
+    assert worker.ble_address == "F8:C7:2C:EC:13:D0"


### PR DESCRIPTION
### Overview
- Introduce ``Settings`` object, to bundle configuration settings.
- Propagate both command line options and environment variables into `Settings` object.

### Details
The program will now understand those configuration settings (command line option vs. environment variable):
- ``--ble-adapter`` / ``CALYPSO_BLE_ADAPTER``
- ``--ble-address`` / ``CALYPSO_BLE_ADDRESS``
- ``--ble-discovery-timeout`` / ``CALYPSO_BLE_DISCOVERY_TIMEOUT``
- ``--ble-connect-timeout`` / ``CALYPSO_BLE_CONNECT_TIMEOUT``
