### PR TITLE
CLI: Use extended settings also for CLI entrypoints `info` and `explore`

### DIFF
--- a/calypso_anemometer/cli.py
+++ b/calypso_anemometer/cli.py
@@ -28,20 +28,6 @@ def cli(ctx, quiet: t.Optional[bool], verbose: t.Optional[bool], debug: t.Option
     setup_logging(level=log_level)
 
 
-@click.command()
-@click.pass_context
-@make_sync
-async def info(ctx):
-    await run_engine(workhorse=CalypsoDeviceApi, handler=lambda calypso: calypso.about())
-
-
-@click.command()
-@click.pass_context
-@make_sync
-async def explore(ctx):
-    await run_engine(workhorse=CalypsoDeviceApi, handler=lambda calypso: calypso.explore())
-
-
 ble_adapter_option = click.option(
     "--ble-adapter",
     envvar="CALYPSO_BLE_ADAPTER",
@@ -81,6 +67,52 @@ rate_option = click.option(
 )
 subscribe_option = click.option("--subscribe", is_flag=True, required=False, help="Continuously receive readings")
 target_option = click.option("--target", type=str, required=False, help="Submit telemetry data to target")
+
+
+@click.command()
+@ble_adapter_option
+@ble_address_option
+@ble_discovery_timeout_option
+@ble_connect_timeout_option
+@click.pass_context
+@make_sync
+async def info(
+    ctx,
+    ble_adapter: t.Optional[str] = None,
+    ble_address: t.Optional[str] = None,
+    ble_discovery_timeout: t.Optional[float] = None,
+    ble_connect_timeout: t.Optional[float] = None,
+):
+    settings = Settings(
+        ble_adapter=ble_adapter,
+        ble_address=ble_address,
+        ble_discovery_timeout=ble_discovery_timeout,
+        ble_connect_timeout=ble_connect_timeout,
+    )
+    await run_engine(workhorse=CalypsoDeviceApi, settings=settings, handler=lambda calypso: calypso.about())
+
+
+@click.command()
+@ble_adapter_option
+@ble_address_option
+@ble_discovery_timeout_option
+@ble_connect_timeout_option
+@click.pass_context
+@make_sync
+async def explore(
+    ctx,
+    ble_adapter: t.Optional[str] = None,
+    ble_address: t.Optional[str] = None,
+    ble_discovery_timeout: t.Optional[float] = None,
+    ble_connect_timeout: t.Optional[float] = None,
+):
+    settings = Settings(
+        ble_adapter=ble_adapter,
+        ble_address=ble_address,
+        ble_discovery_timeout=ble_discovery_timeout,
+        ble_connect_timeout=ble_connect_timeout,
+    )
+    await run_engine(workhorse=CalypsoDeviceApi, settings=settings, handler=lambda calypso: calypso.explore())
 
 
 @click.command()

--- a/calypso_anemometer/util.py
+++ b/calypso_anemometer/util.py
@@ -68,7 +68,7 @@ class EnumChoice(click.Choice):
 
     def convert(self, value: t.Any, param: t.Optional[click.Parameter], ctx: t.Optional[click.Context]) -> t.Any:
         value = super().convert(value=value, param=param, ctx=ctx)
-        if value is None:
+        if value is None:  # pragma: no cover
             return None
         return self.enum_type[value]
 

--- a/doc/backlog.rst
+++ b/doc/backlog.rst
@@ -73,18 +73,27 @@ Topic: QA
 **************
 Iteration +2.5
 **************
-Topic: Production
+Topic: Production I
 
 - [x] Introduce ``Settings`` container entity, for the following three options/settings
 - [x] BLE: Select BLE adapter, using ``--ble-adapter`` or ``CALYPSO_BLE_ADAPTER``
 - [x] BLE: Obtain peripheral address from both ``--ble-address`` or ``CALYPSO_BLE_ADDRESS``
 - [x] BLE: Unlock ``--ble-*-timeout`` or ``CALYPSO_BLE_*_TIMEOUT``
-- [o] Turn off logging to STDOUT
-- [o] Systemd unit, with installer
-- [o] Day/night switching
-- [o] NMEA-0183: Review if sentence termination ``<CR><LF>`` is properly sent.
+- [x] CLI: Turn off logging to STDOUT
+- [x] CLI: Use extended settings also for CLI entrypoints ``info`` and ``explore``
+
+
+**************
+Iteration +2.7
+**************
+Topic: Production II
+
+- [o] Engine: Do we need a retry logic, or should this just be handed over to ``systemd``?
 - [o] Engine: Do we need a thread-based watchdog to kill the asyncio domain
   when it stalls completely? Is there any chance to recover at all?
+- [o] Auxiliary: Add systemd unit file, optionally with installer
+- [o] Auxiliary: Day/night switching
+- [o] NMEA-0183: Review if sentence termination ``<CR><LF>`` is properly sent.
 
 
 ************

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # (c) 2022 Andreas Motl <andreas.motl@panodata.org>
 # License: GNU Affero General Public License, Version 3
+import os
+
 import pytest
 from pytest_mock import MockerFixture
 
@@ -12,3 +14,11 @@ def use_stable_cross_platform_bluetooth_adapter(mocker: MockerFixture):
     Otherwise, the outcome will deviate on Linux vs. macOS.
     """
     mocker.patch("calypso_anemometer.core.get_adapter_name", return_value="hci0")
+
+
+@pytest.fixture(autouse=True)
+def clean_environment_variables(mocker: MockerFixture):
+    """
+    Make sure the tests will run with a deterministic set of application-specific environment variables.
+    """
+    mocker.patch.dict(os.environ, {"CALYPSO_QUIET": "false"})


### PR DESCRIPTION
What the title says.

It is now possible to run `calypso-anemometer info --ble-adapter=hci1 --ble-address=F8:C7:2C:EC:13:D0`.
