### PR TITLE
Little-endian. Proselint. Pictures.

### DIFF
--- a/.proselintrc.json
+++ b/.proselintrc.json
@@ -1,0 +1,5 @@
+{
+  "checks": {
+    "annotations.misc": false
+  }
+}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,7 @@ Changes
   - ``--ble-connect-timeout`` / ``CALYPSO_BLE_CONNECT_TIMEOUT``
 - Add ``--quiet`` option / ``CALYPSO_QUIET`` environment variable for
   silencing output to STDOUT
+- Explicitly use little-endian byte order for decoding binary data
 
 Breaking changes
 ----------------

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ $(eval isort        := $(venv)/bin/isort)
 $(eval pytest       := $(venv)/bin/pytest)
 $(eval twine        := $(venv)/bin/twine)
 $(eval flake8       := $(venv)/bin/pflake8)
+$(eval proselint    := $(venv)/bin/proselint)
 
 setup-virtualenv:
 	@test -e $(python) || python3 -m venv $(venv) || python -m venv $(venv)
@@ -18,6 +19,10 @@ format: setup-virtualenv
 lint: setup-virtualenv
 	$(pip) install --requirement=requirements-utils.txt
 	$(flake8) calypso_anemometer examples testing
+	$(MAKE) proselint
+
+proselint:
+	$(proselint) *.rst doc/**.rst
 
 test: setup-virtualenv
 	$(pip) install --editable=.[test,fake]

--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,14 @@ Hardware device
 The `Calypso UP10 ultrasonic portable solar wind meter`_ is a Bluetooth, solar-powered,
 pocket-sized, ultrasonic anemometer. No power cords or data wires needed.
 
+Pictures:
+
+.. figure:: https://user-images.githubusercontent.com/453543/182049443-385c2a79-621e-41a3-b5ef-ee61f9c14b11.png
+    :alt: Calypso UP10
+    :target: `Calypso UP10 full size images`_
+
+    Calypso UP10.
+
 Resources:
 
 - `Product page <https://calypsoinstruments.com/shop/product/ultrasonic-portable-solar-wind-meter-2>`_
@@ -44,6 +52,7 @@ Resources:
 - `Instruction's manual <https://calypsoinstruments.com/web/content/39973?access_token=a4fb3216-7abd-483d-b2d5-129e86d54142&unique=eb0f37d09f58423b9cac15d4dfa2ecd93d7d5bb3&download=true>`_
 - `User manual <https://www.r-p-r.co.uk/downloads/calypso/Ultrasonic_Portable_User_Manual_EN.pdf>`_
 - `Developer manual <https://www.instrumentchoice.com.au/attachment/download/81440/5f62c29c10d3c987351591.pdf>`_
+
 
 Software library
 ================
@@ -80,7 +89,7 @@ To install the latest development version from the repository, invoke::
 Pre-flight checks
 *****************
 
-There is some documentation about investigating and configuring your Bluetooth/BLE
+We have some documentation about investigating and configuring your Bluetooth/BLE
 stack and about simulating the telemetry messaging. On this matter, you might want
 to run through a sequence of `preflight checks`_ before going into `production`_.
 
@@ -230,8 +239,8 @@ Project information
 Contributions
 =============
 
-Any kind of contribution, feedback or patches are very much welcome! Just `create
-an issue`_ or submit a patch if you think we should include a new feature, or to
+Every kind of contribution, feedback, or patch, is much welcome. `Create an
+issue`_ or submit a patch if you think we should include a new feature, or to
 report or fix a bug.
 
 Development
@@ -256,6 +265,7 @@ The project is licensed under the terms of the GNU AGPL license.
 
 
 .. _Bleak: https://github.com/hbldh/bleak
+.. _Calypso UP10 full size images: https://user-images.githubusercontent.com/453543/182049424-9a249add-c94b-4077-91bf-c864f2ed0e95.png
 .. _Calypso UP10 ultrasonic portable solar wind meter: https://calypsoinstruments.com/shop/product/ultrasonic-portable-solar-wind-meter-2
 .. _CalypsoUltrasonicAPI: https://github.com/volkerpetersen/CalypsoUltrasonicAPI
 .. _create an issue: https://github.com/maritime-labs/calypso-anemometer/issues

--- a/calypso_anemometer/model.py
+++ b/calypso_anemometer/model.py
@@ -131,7 +131,7 @@ class CalypsoReading:
         """
 
         # Decode from binary.
-        data = struct.unpack("HHBBBBH", buffer)
+        data = struct.unpack("<HHBBBBH", buffer)
 
         # Decompose.
         (wind_speed, wind_direction, battery_level, temperature, roll, pitch, compass) = data

--- a/doc/backlog.rst
+++ b/doc/backlog.rst
@@ -81,6 +81,8 @@ Topic: Production I
 - [x] BLE: Unlock ``--ble-*-timeout`` or ``CALYPSO_BLE_*_TIMEOUT``
 - [x] CLI: Turn off logging to STDOUT
 - [x] CLI: Use extended settings also for CLI entrypoints ``info`` and ``explore``
+- [x] Endianness
+- [x] Docs: Picture
 
 
 **************

--- a/requirements-utils.txt
+++ b/requirements-utils.txt
@@ -2,3 +2,4 @@ black
 isort
 pyproject-flake8
 flake8<5
+proselint


### PR DESCRIPTION
- Explicitly use little-endian byte order for decoding binary data.
  > When using native size, the size of the packed value is platform-dependent.
- Obey to `proselint`.
- Docs: Add picture of hardware device.
