### PR TITLE
Rename `reading.compass` to `reading.heading` for better "naming things"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ calypso-anemometer changelog
 
 in progress
 ===========
+- Rename ``reading.compass`` to ``reading.heading`` for better "naming things"
 
 
 2022-08-03 0.5.1

--- a/calypso_anemometer/fake.py
+++ b/calypso_anemometer/fake.py
@@ -19,7 +19,7 @@ MINIMUM_VALUES = CalypsoReading(
     temperature=-100,
     roll=-90,
     pitch=-90,
-    compass=0,
+    heading=0,
 )
 
 MAXIMUM_VALUES = CalypsoReading(
@@ -29,7 +29,7 @@ MAXIMUM_VALUES = CalypsoReading(
     temperature=+100,
     roll=+90,
     pitch=+90,
-    compass=360,
+    heading=360,
 )
 
 

--- a/calypso_anemometer/model.py
+++ b/calypso_anemometer/model.py
@@ -97,7 +97,7 @@ class CalypsoReading:
     temperature: int
     roll: int
     pitch: int
-    compass: int
+    heading: int
 
     @classmethod
     def from_buffer(cls, buffer: bytearray):
@@ -134,7 +134,7 @@ class CalypsoReading:
         data = struct.unpack("<HHBBBBH", buffer)
 
         # Decompose.
-        (wind_speed, wind_direction, battery_level, temperature, roll, pitch, compass) = data
+        (wind_speed, wind_direction, battery_level, temperature, roll, pitch, heading) = data
 
         # Apply adjustments.
         return cls(
@@ -144,7 +144,7 @@ class CalypsoReading:
             temperature=temperature - 100,
             roll=roll - 90,
             pitch=pitch - 90,
-            compass=360 - compass,
+            heading=360 - heading,
         )
 
     def adjusted(self):

--- a/calypso_anemometer/telemetry/signalk.py
+++ b/calypso_anemometer/telemetry/signalk.py
@@ -46,8 +46,8 @@ class SignalKDeltaMessage:
             SignalKDeltaItem(path="environment.wind.speedApparent", value=reading.wind_speed),
             SignalKDeltaItem(path="navigation.attitude.roll", value=reading.roll),
             SignalKDeltaItem(path="navigation.attitude.pitch", value=reading.pitch),
-            SignalKDeltaItem(path="navigation.attitude.yaw", value=reading.compass),
-            SignalKDeltaItem(path="navigation.headingMagnetic", value=reading.compass),
+            SignalKDeltaItem(path="navigation.attitude.yaw", value=reading.heading),
+            SignalKDeltaItem(path="navigation.headingMagnetic", value=reading.heading),
             # TODO: Improve `path` naming.
             SignalKDeltaItem(path="electrical.batteries.99.name", value=self.source),
             SignalKDeltaItem(path="electrical.batteries.99.location", value=self.location),

--- a/examples/calypso_telemetry_nmea0183.py
+++ b/examples/calypso_telemetry_nmea0183.py
@@ -34,7 +34,7 @@ def calypso_nmea0183_telemetry_demo(host="255.255.255.255", port=10110):
         temperature=33,
         roll=30,
         pitch=-60,
-        compass=235,
+        heading=235,
     )
 
     # Broadcast telemetry message, e.g. to OpenCPN.

--- a/examples/calypso_telemetry_signalk.py
+++ b/examples/calypso_telemetry_signalk.py
@@ -34,7 +34,7 @@ def calypso_signalk_telemetry_demo(host="localhost", port=4123):
         temperature=33,
         roll=30,
         pitch=-60,
-        compass=235,
+        heading=235,
     )
 
     # Submit telemetry message to SignalK.

--- a/testing/data.py
+++ b/testing/data.py
@@ -18,7 +18,7 @@ dummy_reading = CalypsoReading(
     temperature=33,
     roll=30,
     pitch=-60,
-    compass=235,
+    heading=235,
 )
 
 # Define example wire messages.

--- a/testing/test_cli.py
+++ b/testing/test_cli.py
@@ -37,7 +37,7 @@ def test_cli_fake_verbose(caplog):
     Test `calypso-anemometer --verbose fake`
     """
     fake_reading = CalypsoReading(
-        wind_speed=1, wind_direction=1, battery_level=1, temperature=-99, roll=-89, pitch=-89, compass=1
+        wind_speed=1, wind_direction=1, battery_level=1, temperature=-99, roll=-89, pitch=-89, heading=1
     )
     runner = CliRunner()
     result = runner.invoke(cli, shlex.split("--verbose fake"), catch_exceptions=False)
@@ -62,7 +62,7 @@ def test_cli_fake_rate(caplog):
     Test `calypso-anemometer --verbose fake --rate=hz_8`
     """
     fake_reading = CalypsoReading(
-        wind_speed=1, wind_direction=1, battery_level=1, temperature=-99, roll=-89, pitch=-89, compass=1
+        wind_speed=1, wind_direction=1, battery_level=1, temperature=-99, roll=-89, pitch=-89, heading=1
     )
     runner = CliRunner()
     result = runner.invoke(cli, shlex.split("--verbose fake --rate=hz_8"), catch_exceptions=False)
@@ -115,7 +115,7 @@ def test_cli_read_stdout_success(caplog):
     response = json.loads(result.stdout)
     assert response == {
         "battery_level": 90,
-        "compass": 235,
+        "heading": 235,
         "pitch": -60,
         "roll": 30,
         "temperature": 33,
@@ -134,7 +134,7 @@ def test_cli_read_stdout_success(caplog):
     assert "Received buffer:  b'9\\x02\\xce\\x00\\t\\x85x\\x1e}\\x00'" in caplog.messages
     assert (
         "Decoded reading: CalypsoReading(wind_speed=5.69, wind_direction=206, battery_level=90, "
-        "temperature=33, roll=30, pitch=-60, compass=235)" in caplog.messages
+        "temperature=33, roll=30, pitch=-60, heading=235)" in caplog.messages
     )
     assert "Disconnecting" in caplog.messages
 
@@ -213,7 +213,7 @@ def test_cli_read_telemetry_success(caplog):
     response = json.loads(result.stdout)
     assert response == {
         "battery_level": 90,
-        "compass": 235,
+        "heading": 235,
         "pitch": -60,
         "roll": 30,
         "temperature": 33,

--- a/testing/test_core_reading.py
+++ b/testing/test_core_reading.py
@@ -35,7 +35,7 @@ async def test_reading_success(mocker: MockerFixture, caplog):
     assert "Received buffer:  b'9\\x02\\xce\\x00\\t\\x85x\\x1e}\\x00'" in caplog.messages
     assert (
         "Decoded reading: CalypsoReading(wind_speed=5.69, wind_direction=206, battery_level=90, "
-        "temperature=33, roll=30, pitch=-60, compass=235)" in caplog.messages
+        "temperature=33, roll=30, pitch=-60, heading=235)" in caplog.messages
     )
     assert "Disconnecting" in caplog.messages
 

--- a/testing/test_fake.py
+++ b/testing/test_fake.py
@@ -30,7 +30,7 @@ async def test_subscribe_once():
         await fake.subscribe_reading(callback=callback_mock, run_once=True)
 
     callback_mock.assert_called_once_with(
-        CalypsoReading(wind_speed=1, wind_direction=1, battery_level=1, temperature=-99, roll=-89, pitch=-89, compass=1)
+        CalypsoReading(wind_speed=1, wind_direction=1, battery_level=1, temperature=-99, roll=-89, pitch=-89, heading=1)
     )
 
 

--- a/testing/test_model.py
+++ b/testing/test_model.py
@@ -21,7 +21,7 @@ def test_decode_wiredata():
     buffer = dummy_wire_message_good
     data = CalypsoReading.from_buffer(buffer)
     assert data == CalypsoReading(
-        wind_speed=5.69, wind_direction=206, battery_level=90, temperature=33, roll=30, pitch=-60, compass=235
+        wind_speed=5.69, wind_direction=206, battery_level=90, temperature=33, roll=30, pitch=-60, heading=235
     )
 
 
@@ -34,7 +34,7 @@ def test_calypso_reading_vanilla():
         "temperature": 33,
         "roll": 30,
         "pitch": -60,
-        "compass": 235,
+        "heading": 235,
     }
 
 
@@ -53,7 +53,7 @@ def test_calypso_reading_adjusted():
         "temperature": 33,
         "roll": 30,
         "pitch": -60,
-        "compass": 235,
+        "heading": 235,
     }
 
 


### PR DESCRIPTION
This patch implements the suggestion at https://github.com/maritime-labs/calypso-anemometer/issues/12#issuecomment-1443709234:

> On a side note: `roll` and `pitch` also come from the gyro, don't they? Should we perhaps rename the `reading.compass` field to `reading.heading` for the sake of better "naming things"?

@UserMacUseface endorsed this improvement.