### PR TITLE
CI: Save resources by only running particular matrix slots on non-Linux

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,15 @@ jobs:
 
     strategy:
       matrix:
-        os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
+        os: [ "ubuntu-latest" ]
         python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
+        # In order to save resources, only run particular
+        # matrix slots on other OS than Linux.
+        include:
+          - os: "macos-latest"
+            python-version: "3.11"
+          - os: "windows-latest"
+            python-version: "3.11"
 
     env:
       OS: ${{ matrix.os }}


### PR DESCRIPTION
What the title says.