### PR TITLE
Compass: Add `--compass=on` option to enable compass

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ in progress
 - SignalK telemetry: Use Radian (rad) unit for angle values
 - SignalK telemetry: Use Kelvin unit for temperature
 - SignalK telemetry: Use ratio (percentage) for battery level
+- Compass: Add ``--compass=on`` option to enable compass
 
 
 2022-08-03 0.5.1

--- a/README.rst
+++ b/README.rst
@@ -113,6 +113,9 @@ default, the Bluetooth adapter ``hci0`` will be used.
     # Get device reading.
     calypso-anemometer read
 
+    # Get device reading, with compass (roll, pitch, heading).
+    calypso-anemometer read --compass=on
+
     # Get device readings, continuously at 4 Hz (default).
     calypso-anemometer read --subscribe
 

--- a/calypso_anemometer/core.py
+++ b/calypso_anemometer/core.py
@@ -27,6 +27,7 @@ from calypso_anemometer.exception import (
 )
 from calypso_anemometer.model import (
     BleCharSpec,
+    CalypsoDeviceCompassStatus,
     CalypsoDeviceDataRate,
     CalypsoDeviceInfo,
     CalypsoDeviceInfoCharacteristic,
@@ -210,6 +211,14 @@ class CalypsoDeviceApi:
         logger.info(f"Setting data rate to {rate}")
         await self.client.write_gatt_char(
             CalypsoDeviceStatusCharacteristic.rate.value.uuid, data=bytes([rate.value]), response=True
+        )
+
+    async def set_compass(self, compass: CalypsoDeviceCompassStatus):
+        if compass is None:
+            return
+        logger.info(f"Setting compass status to {compass}")
+        await self.client.write_gatt_char(
+            CalypsoDeviceStatusCharacteristic.compass.value.uuid, data=bytes([compass.value]), response=True
         )
 
     async def get_reading(self):

--- a/calypso_anemometer/engine.py
+++ b/calypso_anemometer/engine.py
@@ -7,7 +7,7 @@ import typing as t
 
 from calypso_anemometer.core import CalypsoDeviceApi
 from calypso_anemometer.exception import CalypsoError
-from calypso_anemometer.model import CalypsoDeviceDataRate, CalypsoReading, Settings
+from calypso_anemometer.model import CalypsoDeviceCompassStatus, CalypsoDeviceDataRate, CalypsoReading, Settings
 from calypso_anemometer.telemetry.adapter import TelemetryAdapter
 from calypso_anemometer.util import wait_forever
 
@@ -32,6 +32,7 @@ async def handler_factory(
     subscribe: bool = False,
     target: t.Optional[str] = None,
     rate: t.Optional[CalypsoDeviceDataRate] = None,
+    compass: t.Optional[CalypsoDeviceCompassStatus] = None,
     quiet: bool = False,
 ) -> t.Callable:
     """
@@ -40,6 +41,7 @@ async def handler_factory(
     :param subscribe: Whether to run in one-shot or continuous mode.
     :param target: Where to submit telemetry data to, and how.
     :param rate: At which rate to sample the readings.
+    :param compass: If the compass should be enabled or not.
     :param quiet: Do not print to stdout or stderr.
 
     :return: An asynchronous handler function accepting a reference to a workhorse instance.
@@ -66,6 +68,9 @@ async def handler_factory(
 
     # Main handler, which receives readings.
     async def handler(calypso: CalypsoDeviceApi):
+        # Optionally enable compass.
+        await calypso.set_compass(compass)
+
         # One-shot reading.
         if not subscribe:
             reading = await calypso.get_reading()

--- a/calypso_anemometer/fake.py
+++ b/calypso_anemometer/fake.py
@@ -8,7 +8,7 @@ from typing import Callable, Optional
 
 import aiorate
 
-from calypso_anemometer.model import CalypsoDeviceDataRate, CalypsoReading, Settings
+from calypso_anemometer.model import CalypsoDeviceCompassStatus, CalypsoDeviceDataRate, CalypsoReading, Settings
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +43,7 @@ class CalypsoDeviceApiFake:
         self.settings = settings
         self.ble_address = settings.ble_address
         self.datarate: CalypsoDeviceDataRate = CalypsoDeviceDataRate.HZ_4
+        self.compass: CalypsoDeviceCompassStatus = CalypsoDeviceCompassStatus.OFF
         self.reading: Optional[CalypsoReading] = None
 
     async def __aenter__(self):
@@ -66,6 +67,9 @@ class CalypsoDeviceApiFake:
 
     async def set_datarate(self, rate: CalypsoDeviceDataRate):
         self.datarate = rate
+
+    async def set_compass(self, compass: CalypsoDeviceCompassStatus):
+        self.compass = compass
 
     async def get_reading(self):
         logger.info("Producing reading")

--- a/testing/test_cli.py
+++ b/testing/test_cli.py
@@ -147,13 +147,13 @@ def test_cli_read_stdout_success(caplog):
 @mock.patch("calypso_anemometer.core.BleakClient.write_gatt_char", AsyncMock(return_value=None))
 @mock.patch("calypso_anemometer.core.BleakClient.start_notify", AsyncMock(return_value=None))
 @mock.patch("calypso_anemometer.engine.wait_forever", AsyncMock(return_value=None))
-def test_cli_subscribe_stdout_success(caplog):
+def test_cli_subscribe_rate_compass_stdout_success(caplog):
     """
     Test successful `calypso-anemometer read --subscribe`
     """
 
     runner = CliRunner()
-    result = runner.invoke(cli, ["read", "--subscribe", "--rate=HZ_8"], catch_exceptions=False)
+    result = runner.invoke(cli, ["read", "--subscribe", "--rate=HZ_8", "--compass=on"], catch_exceptions=False)
     assert result.exit_code == 0
 
     # TODO: Currently no reading is emitted and processed, because `start_notify` is mocked
@@ -164,6 +164,7 @@ def test_cli_subscribe_stdout_success(caplog):
     assert "Found device at address: bar: foo" in caplog.messages
     assert "Connecting to device at 'bar' with adapter 'hci0'" in caplog.messages
     assert "Setting data rate to 8" in caplog.messages
+    assert "Setting compass status to 1" in caplog.messages
     assert "Subscribing to readings" in caplog.messages
     assert "Disconnecting" in caplog.messages
 

--- a/testing/test_fake.py
+++ b/testing/test_fake.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock
 import pytest
 
 from calypso_anemometer.fake import MAXIMUM_VALUES, MINIMUM_VALUES, CalypsoDeviceApiFake
-from calypso_anemometer.model import CalypsoDeviceDataRate, CalypsoReading
+from calypso_anemometer.model import CalypsoDeviceCompassStatus, CalypsoDeviceDataRate, CalypsoReading
 
 
 @pytest.mark.asyncio
@@ -26,6 +26,7 @@ async def test_set_datarate():
 async def test_subscribe_once():
     callback_mock = Mock()
     async with CalypsoDeviceApiFake() as fake:
+        await fake.set_compass(CalypsoDeviceCompassStatus.ON)
         await fake.set_datarate(CalypsoDeviceDataRate.HZ_8)
         await fake.subscribe_reading(callback=callback_mock, run_once=True)
 


### PR DESCRIPTION
At https://github.com/maritime-labs/calypso-anemometer/issues/12#issuecomment-1443858206, we discovered that there have not been any methods or options for enabling the compass yet. This patch brings in the corresponding improvements.