### PR TITLE
NMEA0183 telemetry: Emit `compass/{heading,pitch,roll}` data using `$MLHDT` and `$MLXDR` sentences

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ in progress
 - SignalK telemetry: Use ratio (percentage) for battery level
 - Compass: Add ``--compass=on`` option to enable compass
 - NMEA0183 telemetry: Use ``$MLVWR`` sentence prefix for wind data
+- NMEA0183 telemetry: Emit compass/heading data using ``$MLHDT`` sentence
 
 
 2022-08-03 0.5.1

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ in progress
 - SignalK telemetry: Use Kelvin unit for temperature
 - SignalK telemetry: Use ratio (percentage) for battery level
 - Compass: Add ``--compass=on`` option to enable compass
+- NMEA0183 telemetry: Use ``$MLVWR`` sentence prefix for wind data
 
 
 2022-08-03 0.5.1

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ in progress
 - Compass: Add ``--compass=on`` option to enable compass
 - NMEA0183 telemetry: Use ``$MLVWR`` sentence prefix for wind data
 - NMEA0183 telemetry: Emit compass/heading data using ``$MLHDT`` sentence
+- NMEA0183 telemetry: Emit compass/pitch+roll data using ``$MLXDR`` sentence
 
 
 2022-08-03 0.5.1

--- a/README.rst
+++ b/README.rst
@@ -203,7 +203,7 @@ like outlined in those screenshots.
 
 An example NMEA-0183 sentence emitted is::
 
-    $IIVWR,154.0,L,11.06,N,5.69,M,20.48,K*65
+    $MLVWR,154.0,L,11.06,N,5.69,M,20.48,K*65
 
 
 **************

--- a/calypso_anemometer/telemetry/network.py
+++ b/calypso_anemometer/telemetry/network.py
@@ -34,12 +34,12 @@ class NetworkTelemetry:
                 self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
 
     def send(self, payload: str, newline=True):
-        logger.info(f"Sending message to {self.protocol.value}://{self.host}:{self.port}. {payload}")
+        logger.info(f"Sending message to {self.protocol.value}://{self.host}:{self.port}\n{payload}")
         address = (self.host, self.port)
         if isinstance(payload, str):
             payload = payload.encode("utf-8")
         if newline:
-            payload += b"\n"
+            payload += b"\r\n"
         if self.protocol == NetworkProtocol.TCP:
             self.socket.connect(address)
             self.socket.send(payload)

--- a/calypso_anemometer/telemetry/nmea0183.py
+++ b/calypso_anemometer/telemetry/nmea0183.py
@@ -94,14 +94,14 @@ class Nmea0183GenericMessage:
 
 
 @dataclasses.dataclass
-class Nmea0183MessageIIVWR:
+class Nmea0183MessageVWR:
     """
-    Represent and serialize NMEA-0183 IIVWR message.
+    Represent and serialize NMEA-0183 VWR message.
 
     VWR - Relative Wind Speed and Angle
     """
 
-    IDENTIFIER = "$IIVWR"
+    IDENTIFIER = "$MLVWR"
     direction_degrees: float
     speed_meters_per_second: float
 
@@ -173,14 +173,14 @@ class Nmea0183Envelope:
 
     def set_reading(self, reading: CalypsoReading):
         """
-        Derive NMEA-0183 IIVWR message from measurement reading.
+        Derive NMEA-0183 VWR message from measurement reading.
         """
         reading = reading.adjusted()
-        iivwr = Nmea0183MessageIIVWR(
+        vwr = Nmea0183MessageVWR(
             direction_degrees=reading.wind_direction,
             speed_meters_per_second=reading.wind_speed,
         )
-        self.items = [iivwr.to_message()]
+        self.items = [vwr.to_message()]
 
     def aslist(self):
         """

--- a/doc/preflight.rst
+++ b/doc/preflight.rst
@@ -74,7 +74,7 @@ Install::
 
 Submit::
 
-    echo '$IIVWR,045.0,L,12.6,N,6.5,M,23.3,K*52' | socat -u - udp-datagram:255.255.255.255:10110,bind=:56123,broadcast
+    echo '$MLVWR,045.0,L,12.6,N,6.5,M,23.3,K' | socat -u - udp-datagram:255.255.255.255:10110,bind=:56123,broadcast
 
 Receive::
 

--- a/testing/test_cli.py
+++ b/testing/test_cli.py
@@ -222,7 +222,7 @@ def test_cli_read_telemetry_success(caplog):
         "wind_speed": 5.69,
     }
 
-    assert "Sending message to udp://255.255.255.255:60110. $IIVWR,154.0,L,11.06,N,5.69,M,20.48,K*65" in caplog.messages
+    assert "Sending message to udp://255.255.255.255:60110. $MLVWR,154.0,L,11.06,N,5.69,M,20.48,K*64" in caplog.messages
 
 
 @mock.patch(

--- a/testing/test_cli.py
+++ b/testing/test_cli.py
@@ -225,7 +225,8 @@ def test_cli_read_telemetry_success(caplog):
     assert (
         "Sending message to udp://255.255.255.255:60110\n"
         "$MLHDT,235.0,T*27\r\n"
-        "$MLVWR,154.0,L,11.06,N,5.69,M,20.48,K*64" in caplog.messages
+        "$MLVWR,154.0,L,11.06,N,5.69,M,20.48,K*64\r\n"
+        "$MLXDR,A,-60.0,D,PTCH#CAL,A,30.0,D,ROLL#CAL*75" in caplog.messages
     )
 
 

--- a/testing/test_cli.py
+++ b/testing/test_cli.py
@@ -222,7 +222,11 @@ def test_cli_read_telemetry_success(caplog):
         "wind_speed": 5.69,
     }
 
-    assert "Sending message to udp://255.255.255.255:60110. $MLVWR,154.0,L,11.06,N,5.69,M,20.48,K*64" in caplog.messages
+    assert (
+        "Sending message to udp://255.255.255.255:60110\n"
+        "$MLHDT,235.0,T*27\r\n"
+        "$MLVWR,154.0,L,11.06,N,5.69,M,20.48,K*64" in caplog.messages
+    )
 
 
 @mock.patch(

--- a/testing/test_examples.py
+++ b/testing/test_examples.py
@@ -12,4 +12,4 @@ def test_telemetry_signalk_demo(caplog):
 
 def test_telemetry_nmea0183_demo(caplog):
     calypso_nmea0183_telemetry_demo(port=60110)
-    assert "Sending message to udp://255.255.255.255:60110. $IIVWR,154.0,L,11.06,N,5.69,M,20.48,K*65" in caplog.messages
+    assert "Sending message to udp://255.255.255.255:60110. $MLVWR,154.0,L,11.06,N,5.69,M,20.48,K*64" in caplog.messages

--- a/testing/test_examples.py
+++ b/testing/test_examples.py
@@ -12,4 +12,8 @@ def test_telemetry_signalk_demo(caplog):
 
 def test_telemetry_nmea0183_demo(caplog):
     calypso_nmea0183_telemetry_demo(port=60110)
-    assert "Sending message to udp://255.255.255.255:60110. $MLVWR,154.0,L,11.06,N,5.69,M,20.48,K*64" in caplog.messages
+    assert (
+        "Sending message to udp://255.255.255.255:60110\n"
+        "$MLHDT,235.0,T*27\r\n"
+        "$MLVWR,154.0,L,11.06,N,5.69,M,20.48,K*64" in caplog.messages
+    )

--- a/testing/test_examples.py
+++ b/testing/test_examples.py
@@ -15,5 +15,6 @@ def test_telemetry_nmea0183_demo(caplog):
     assert (
         "Sending message to udp://255.255.255.255:60110\n"
         "$MLHDT,235.0,T*27\r\n"
-        "$MLVWR,154.0,L,11.06,N,5.69,M,20.48,K*64" in caplog.messages
+        "$MLVWR,154.0,L,11.06,N,5.69,M,20.48,K*64\r\n"
+        "$MLXDR,A,-60.0,D,PTCH#CAL,A,30.0,D,ROLL#CAL*75" in caplog.messages
     )

--- a/testing/test_telemetry.py
+++ b/testing/test_telemetry.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 import pytest
 
 from calypso_anemometer.telemetry.adapter import TelemetryAdapter
-from calypso_anemometer.telemetry.nmea0183 import Nmea0183Envelope, Nmea0183MessageIIVWR
+from calypso_anemometer.telemetry.nmea0183 import Nmea0183Envelope, Nmea0183MessageVWR
 from calypso_anemometer.telemetry.signalk import SignalKDeltaMessage
 from testing.data import dummy_reading
 
@@ -43,7 +43,7 @@ def test_telemetry_nmea0183_wind_into():
     reading = deepcopy(dummy_reading)
     reading.wind_direction = 0
     bucket.set_reading(reading)
-    assert bucket.render() == "$IIVWR,0.0,,11.06,N,5.69,M,20.48,K*29"
+    assert bucket.render() == "$MLVWR,0.0,,11.06,N,5.69,M,20.48,K*28"
 
 
 def test_telemetry_nmea0183_wind_downwind():
@@ -51,7 +51,7 @@ def test_telemetry_nmea0183_wind_downwind():
     reading = deepcopy(dummy_reading)
     reading.wind_direction = 180
     bucket.set_reading(reading)
-    assert bucket.render() == "$IIVWR,180.0,,11.06,N,5.69,M,20.48,K*20"
+    assert bucket.render() == "$MLVWR,180.0,,11.06,N,5.69,M,20.48,K*21"
 
 
 def test_telemetry_nmea0183_wind_left_of_bow():
@@ -59,7 +59,7 @@ def test_telemetry_nmea0183_wind_left_of_bow():
     reading = deepcopy(dummy_reading)
     reading.wind_direction = 206
     bucket.set_reading(reading)
-    assert bucket.render() == "$IIVWR,154.0,L,11.06,N,5.69,M,20.48,K*65"
+    assert bucket.render() == "$MLVWR,154.0,L,11.06,N,5.69,M,20.48,K*64"
 
 
 def test_telemetry_nmea0183_wind_right_of_bow():
@@ -67,7 +67,7 @@ def test_telemetry_nmea0183_wind_right_of_bow():
     reading = deepcopy(dummy_reading)
     reading.wind_direction = 42
     bucket.set_reading(reading)
-    assert bucket.render() == "$IIVWR,42.0,R,11.06,N,5.69,M,20.48,K*4D"
+    assert bucket.render() == "$MLVWR,42.0,R,11.06,N,5.69,M,20.48,K*4C"
 
 
 def test_telemetry_nmea0183_wind_zero():
@@ -75,17 +75,17 @@ def test_telemetry_nmea0183_wind_zero():
     reading = deepcopy(dummy_reading)
     reading.wind_speed = 0
     bucket.set_reading(reading)
-    assert bucket.render() == "$IIVWR,0.0,,0.0,N,0.0,M,0.0,K*1B"
+    assert bucket.render() == "$MLVWR,0.0,,0.0,N,0.0,M,0.0,K*1A"
 
 
-def test_nmea0183messageiivwr_convert_value():
-    assert Nmea0183MessageIIVWR.convert_value(42.42) == 42.42
-    assert Nmea0183MessageIIVWR.convert_value(None) == ""
+def test_nmea0183message_vwr_convert_value():
+    assert Nmea0183MessageVWR.convert_value(42.42) == 42.42
+    assert Nmea0183MessageVWR.convert_value(None) == ""
 
 
-def test_nmea0183messageiivwr_render_success():
-    bucket = Nmea0183MessageIIVWR(direction_degrees=42.42, speed_meters_per_second=5.42)
-    assert bucket.to_message().render() == "$IIVWR,42.42,R,10.54,N,5.42,M,19.51,K*76"
+def test_nmea0183message_vwr_render_success():
+    bucket = Nmea0183MessageVWR(direction_degrees=42.42, speed_meters_per_second=5.42)
+    assert bucket.to_message().render() == "$MLVWR,42.42,R,10.54,N,5.42,M,19.51,K*77"
 
 
 def test_telemetry_adapter_signalk_success():

--- a/testing/test_telemetry.py
+++ b/testing/test_telemetry.py
@@ -86,6 +86,14 @@ def test_telemetry_nmea0183_compass_heading():
     assert "$MLHDT,235.0,T*27" in bucket.render()
 
 
+def test_telemetry_nmea0183_compass_pitch_roll():
+    bucket = Nmea0183Envelope()
+    reading = deepcopy(dummy_reading)
+    reading.wind_speed = 0
+    bucket.set_reading(reading)
+    assert "$MLXDR,A,-60.0,D,PTCH#CAL,A,30.0,D,ROLL#CAL*75" in bucket.render()
+
+
 def test_nmea0183message_vwr_float_value():
     assert Nmea0183MessageVWR.float_value(42.42) == 42.42
     assert Nmea0183MessageVWR.float_value(None) == ""

--- a/testing/test_telemetry.py
+++ b/testing/test_telemetry.py
@@ -43,7 +43,7 @@ def test_telemetry_nmea0183_wind_into():
     reading = deepcopy(dummy_reading)
     reading.wind_direction = 0
     bucket.set_reading(reading)
-    assert bucket.render() == "$MLVWR,0.0,,11.06,N,5.69,M,20.48,K*28"
+    assert "$MLVWR,0.0,,11.06,N,5.69,M,20.48,K*28" in bucket.render()
 
 
 def test_telemetry_nmea0183_wind_downwind():
@@ -51,7 +51,7 @@ def test_telemetry_nmea0183_wind_downwind():
     reading = deepcopy(dummy_reading)
     reading.wind_direction = 180
     bucket.set_reading(reading)
-    assert bucket.render() == "$MLVWR,180.0,,11.06,N,5.69,M,20.48,K*21"
+    assert "$MLVWR,180.0,,11.06,N,5.69,M,20.48,K*21" in bucket.render()
 
 
 def test_telemetry_nmea0183_wind_left_of_bow():
@@ -59,7 +59,7 @@ def test_telemetry_nmea0183_wind_left_of_bow():
     reading = deepcopy(dummy_reading)
     reading.wind_direction = 206
     bucket.set_reading(reading)
-    assert bucket.render() == "$MLVWR,154.0,L,11.06,N,5.69,M,20.48,K*64"
+    assert "$MLVWR,154.0,L,11.06,N,5.69,M,20.48,K*64" in bucket.render()
 
 
 def test_telemetry_nmea0183_wind_right_of_bow():
@@ -67,7 +67,7 @@ def test_telemetry_nmea0183_wind_right_of_bow():
     reading = deepcopy(dummy_reading)
     reading.wind_direction = 42
     bucket.set_reading(reading)
-    assert bucket.render() == "$MLVWR,42.0,R,11.06,N,5.69,M,20.48,K*4C"
+    assert "$MLVWR,42.0,R,11.06,N,5.69,M,20.48,K*4C" in bucket.render()
 
 
 def test_telemetry_nmea0183_wind_zero():
@@ -75,17 +75,25 @@ def test_telemetry_nmea0183_wind_zero():
     reading = deepcopy(dummy_reading)
     reading.wind_speed = 0
     bucket.set_reading(reading)
-    assert bucket.render() == "$MLVWR,0.0,,0.0,N,0.0,M,0.0,K*1A"
+    assert "$MLVWR,0.0,,0.0,N,0.0,M,0.0,K*1A" in bucket.render()
 
 
-def test_nmea0183message_vwr_convert_value():
-    assert Nmea0183MessageVWR.convert_value(42.42) == 42.42
-    assert Nmea0183MessageVWR.convert_value(None) == ""
+def test_telemetry_nmea0183_compass_heading():
+    bucket = Nmea0183Envelope()
+    reading = deepcopy(dummy_reading)
+    reading.wind_speed = 0
+    bucket.set_reading(reading)
+    assert "$MLHDT,235.0,T*27" in bucket.render()
+
+
+def test_nmea0183message_vwr_float_value():
+    assert Nmea0183MessageVWR.float_value(42.42) == 42.42
+    assert Nmea0183MessageVWR.float_value(None) == ""
 
 
 def test_nmea0183message_vwr_render_success():
     bucket = Nmea0183MessageVWR(direction_degrees=42.42, speed_meters_per_second=5.42)
-    assert bucket.to_message().render() == "$MLVWR,42.42,R,10.54,N,5.42,M,19.51,K*77"
+    assert "$MLVWR,42.42,R,10.54,N,5.42,M,19.51,K*77" in bucket.to_message().render()
 
 
 def test_telemetry_adapter_signalk_success():


### PR DESCRIPTION
At https://github.com/maritime-labs/calypso-anemometer/issues/12#issuecomment-1444161597 ff., we discussed the NMEA0183 telemetry sentence format for emitting heading, pitch, and roll values. This patch implements it. An example payload, including multiple sentences, and wind information, is now:
```
$MLHDT,235.0,T*27
$MLVWR,154.0,L,11.06,N,5.69,M,20.48,K*64
$MLXDR,A,-60.0,D,PTCH#CAL,A,30.0,D,ROLL#CAL*75
```
