### PR TITLE
NMEA0183 telemetry: Emit "air temperature" and "battery level" data using `$MLXDR` sentences

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,14 @@ on:
   pull_request:
     branches: [ main ]
 
+  # Allow job to be triggered manually.
+  workflow_dispatch:
+
+# Cancel in-progress jobs when pushing to the same branch.
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
 
   tests:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ in progress
 - NMEA0183 telemetry: Use ``$MLVWR`` sentence prefix for wind data
 - NMEA0183 telemetry: Emit compass/heading data using ``$MLHDT`` sentence
 - NMEA0183 telemetry: Emit compass/pitch+roll data using ``$MLXDR`` sentence
+- NMEA0183 telemetry: Emit air temperature and battery level data using ``$MLXDR`` sentences
 
 
 2022-08-03 0.5.1

--- a/README.rst
+++ b/README.rst
@@ -201,9 +201,13 @@ like outlined in those screenshots.
 
     Configured NMEA-0183 UDP receiver on port 10110.
 
-An example NMEA-0183 sentence emitted is::
+An example NMEA-0183 payload, including multiple sentences, is::
 
-    $MLVWR,154.0,L,11.06,N,5.69,M,20.48,K*65
+    $MLHDT,235.0,T*27
+    $MLVWR,154.0,L,11.06,N,5.69,M,20.48,K*64
+    $MLXDR,A,-60.0,D,PTCH#CAL,A,30.0,D,ROLL#CAL*75
+    $MLXDR,C,33.0,C,AIRTEMP#CAL*6A
+    $MLXDR,L,0.9,R,BATT#CAL*18
 
 
 **************

--- a/testing/test_cli.py
+++ b/testing/test_cli.py
@@ -226,7 +226,9 @@ def test_cli_read_telemetry_success(caplog):
         "Sending message to udp://255.255.255.255:60110\n"
         "$MLHDT,235.0,T*27\r\n"
         "$MLVWR,154.0,L,11.06,N,5.69,M,20.48,K*64\r\n"
-        "$MLXDR,A,-60.0,D,PTCH#CAL,A,30.0,D,ROLL#CAL*75" in caplog.messages
+        "$MLXDR,A,-60.0,D,PTCH#CAL,A,30.0,D,ROLL#CAL*75\r\n"
+        "$MLXDR,C,33.0,C,AIRTEMP#CAL*6A\r\n"
+        "$MLXDR,L,0.9,R,BATT#CAL*18" in caplog.messages
     )
 
 

--- a/testing/test_examples.py
+++ b/testing/test_examples.py
@@ -16,5 +16,7 @@ def test_telemetry_nmea0183_demo(caplog):
         "Sending message to udp://255.255.255.255:60110\n"
         "$MLHDT,235.0,T*27\r\n"
         "$MLVWR,154.0,L,11.06,N,5.69,M,20.48,K*64\r\n"
-        "$MLXDR,A,-60.0,D,PTCH#CAL,A,30.0,D,ROLL#CAL*75" in caplog.messages
+        "$MLXDR,A,-60.0,D,PTCH#CAL,A,30.0,D,ROLL#CAL*75\r\n"
+        "$MLXDR,C,33.0,C,AIRTEMP#CAL*6A\r\n"
+        "$MLXDR,L,0.9,R,BATT#CAL*18" in caplog.messages
     )

--- a/testing/test_telemetry.py
+++ b/testing/test_telemetry.py
@@ -81,7 +81,6 @@ def test_telemetry_nmea0183_wind_zero():
 def test_telemetry_nmea0183_compass_heading():
     bucket = Nmea0183Envelope()
     reading = deepcopy(dummy_reading)
-    reading.wind_speed = 0
     bucket.set_reading(reading)
     assert "$MLHDT,235.0,T*27" in bucket.render()
 
@@ -89,9 +88,22 @@ def test_telemetry_nmea0183_compass_heading():
 def test_telemetry_nmea0183_compass_pitch_roll():
     bucket = Nmea0183Envelope()
     reading = deepcopy(dummy_reading)
-    reading.wind_speed = 0
     bucket.set_reading(reading)
     assert "$MLXDR,A,-60.0,D,PTCH#CAL,A,30.0,D,ROLL#CAL*75" in bucket.render()
+
+
+def test_telemetry_nmea0183_air_temperature():
+    bucket = Nmea0183Envelope()
+    reading = deepcopy(dummy_reading)
+    bucket.set_reading(reading)
+    assert "$MLXDR,C,33.0,C,AIRTEMP#CAL*6A" in bucket.render()
+
+
+def test_telemetry_nmea0183_battery_level():
+    bucket = Nmea0183Envelope()
+    reading = deepcopy(dummy_reading)
+    bucket.set_reading(reading)
+    assert "$MLXDR,L,0.9,R,BATT#CAL*18" in bucket.render()
 
 
 def test_nmea0183message_vwr_float_value():


### PR DESCRIPTION
At GH-21, we discussed the NMEA0183 telemetry sentence format for emitting "air temperature" and "battery level" values. This patch implements it. An example payload, including all available data provided by the Calypso UP10, is now:
```
$MLHDT,235.0,T*27
$MLVWR,154.0,L,11.06,N,5.69,M,20.48,K*64
$MLXDR,A,-60.0,D,PTCH#CAL,A,30.0,D,ROLL#CAL*75
$MLXDR,C,33.0,C,AIRTEMP#CAL*6A
$MLXDR,L,0.9,R,BATT#CAL*18
```
