### PR TITLE
Documentation: Update links to different developer manuals (1.0 vs. 1.8)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,8 @@ Resources:
 - `Data sheet <https://calypsoinstruments.com/web/content/39971?access_token=09db51b3-1ad2-4900-b687-fae6c996fbd0&unique=293e2d5d7c89c38f45731af5c582a49de51ef64c&download=true>`_
 - `Instruction's manual <https://calypsoinstruments.com/web/content/39973?access_token=a4fb3216-7abd-483d-b2d5-129e86d54142&unique=eb0f37d09f58423b9cac15d4dfa2ecd93d7d5bb3&download=true>`_
 - `User manual <https://www.r-p-r.co.uk/downloads/calypso/Ultrasonic_Portable_User_Manual_EN.pdf>`_
-- `Developer manual <https://www.instrumentchoice.com.au/attachment/download/81440/5f62c29c10d3c987351591.pdf>`_
+- `Developer manual 1.0 <https://calypsoinstruments.com/web/content/58404?access_token=f7918efc-ac78-46ba-bb6c-7c719e64f26f&download=true>`_
+- `Developer manual 1.8 <https://www.instrumentchoice.com.au/attachment/download/81440/5f62c29c10d3c987351591.pdf>`_
 
 
 Software library

--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,7 @@ Resources:
 - `User manual <https://www.r-p-r.co.uk/downloads/calypso/Ultrasonic_Portable_User_Manual_EN.pdf>`_
 - `Developer manual 1.0 <https://calypsoinstruments.com/web/content/58404?access_token=f7918efc-ac78-46ba-bb6c-7c719e64f26f&download=true>`_
 - `Developer manual 1.8 <https://www.instrumentchoice.com.au/attachment/download/81440/5f62c29c10d3c987351591.pdf>`_
+- `FAQ <https://calypsoinstruments.com/web/content/884?unique=4fc29abd11ac390bd380e291dadd02f41af6f2b8&download=true>`_
 
 
 Software library


### PR DESCRIPTION
## About
While investigating woes with the eCompass at GH-27, we discovered that there are two different developer manuals.
- [Developer manual 1.0], called CALYPSO ULTRASONIC Portable Solar & Mini Developer Manual.
- [Developer manual 1.8], called CALYPSO ULTRASONIC DEVELOPER MANUAL 1.8.

While we used the second one until now, the [product page](https://calypsoinstruments.com/shop/product/ultrasonic-portable-solar-wind-meter-2#attr=62) now links to the first one.

## Differences

The most prominent differences are that the [Developer manual 1.8] outlines the eCompass calibration procedure, while the [Developer manual 1.0] does not.

```
eCompass Calibration Characteristic: Read/Write
UUID: 0xA008
  0x01->Calibration Mode
  0x00-> Normal mode
Instructions:
1step -> Activate Clinometer and eCompass (UUID: 0xA003)
2step -> Put in calibration Mode send 0x01
3step -> Rotate the device 360 degrees as slow as possible, repeat
4step -> Save data in flash memory, send 0x00 (Normal mode)
```

Also, while the [Developer manual 1.8] still shows a wide range of supported sensors...

![image](https://user-images.githubusercontent.com/453543/221358161-061b80fe-7e58-4c44-a760-62b5f6228df0.png)

the [Developer manual 1.0] now shows only a very narrow table. The column names are a bit unreadable on the image, but they actually are "Wind Speed", "Wind Direction", "Battery level".

![image](https://user-images.githubusercontent.com/453543/221358168-27f45a0f-c6f1-41b4-9517-48a26696ed43.png)


[Developer manual 1.0]: https://calypsoinstruments.com/web/content/58404?access_token=f7918efc-ac78-46ba-bb6c-7c719e64f26f&download=true
[Developer manual 1.8]: https://www.instrumentchoice.com.au/attachment/download/81440/5f62c29c10d3c987351591.pdf
